### PR TITLE
Update RocstarProcessor.pm

### DIFF
--- a/Rocprep/RocstarProcessor.pm
+++ b/Rocprep/RocstarProcessor.pm
@@ -70,7 +70,7 @@ sub checkNDA {
 
     # check Rocmop files
     if ($props->processModule("ROCMOP")) {
-        if (!analyzeRocburn($baseDir)) {
+        if (!analyzeRocmop($baseDir)) {
             $log->processErrorCode(405, $baseDir);
             push(@error, 405);
         };


### PR DESCRIPTION
Fix typo where when checking the Rocmop files, the analyzeRocburn sub is called instead of the analyzeRocmop sub. This error manifests only when prepping a FluidAlone run with no burn module.